### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 		configFile     = flag.String("c", "./wgcf-profile.ini", "ini config file path")
 		endpoint       = flag.String("e", "notset", "warp clean ip")
 		license        = flag.String("k", "notset", "license key")
+		hostbind       = flag.String("h" , false , "bind to 0.0.0.0 instead of local host" )
 		country        = flag.String("country", "", "psiphon country code in ISO 3166-1 alpha-2 format")
 		psiphonEnabled = flag.Bool("cfon", false, "enable psiphonEnabled over warp")
 		pbind          = "127.0.0.1:8086"
@@ -37,7 +38,7 @@ func main() {
 
 	if *psiphonEnabled {
 		pbind = *bindAddress
-		randomBind, err := findFreePort()
+		randomBind, err := findFreePort(*hostbind)
 		if err != nil {
 			log.Fatal("unable to find a free port :/")
 		}
@@ -88,9 +89,14 @@ func main() {
 	log.Println("Bye!")
 }
 
-func findFreePort() (string, error) {
+func findFreePort(hostflag bool) (string, error) {
 	// Listen on TCP port 0, which tells the OS to pick a free port.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if  hostflag {
+		listener, err := net.Listen("tcp", "0.0.0.0:0")
+	} else
+	{
+		listener, err := net.Listen("tcp", "127.0.0.1:0")	
+	}
 	if err != nil {
 		return "", err // Return error if unable to listen on a port
 	}


### PR DESCRIPTION
added -h flag to make the host bind to 0.0.0.0 instead of localhost, 

the usage for this is ease of use when deploying on an Iran based server to allow connecting to warp using a simple socks config which is much easier to deploy.

original functionality is preserved for security purposes.