### PR TITLE
added: flags validations

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,40 +3,141 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/bepass-org/wireguard-go/app"
+	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/bepass-org/wireguard-go/app"
 )
 
-func usage() {
-	log.Println("Usage: wiresocks [-v] [-b addr:port] [-l license] <config file path>")
-	flag.PrintDefaults()
+type Flags struct {
+	Verbose        bool
+	BindAddress    string
+	Endpoint       string
+	License        string
+	Country        string
+	PsiphonEnabled bool
+	Gool           bool
+	Scan           bool
 }
 
-func main() {
-	var (
-		verbose        = flag.Bool("v", false, "verbose")
-		bindAddress    = flag.String("b", "127.0.0.1:8086", "socks bind address")
-		endpoint       = flag.String("e", "notset", "warp clean ip")
-		license        = flag.String("k", "notset", "license key")
-		country        = flag.String("country", "", "psiphon country code in ISO 3166-1 alpha-2 format")
-		psiphonEnabled = flag.Bool("cfon", false, "enable psiphonEnabled over warp")
-		gool           = flag.Bool("gool", false, "enable warp gooling")
-		scan           = flag.Bool("scan", false, "enable warp scanner(experimental)")
-		rtt            = flag.Int("rtt", 1000, "scanner rtt threshold, default 1000")
-	)
+var validFlags = map[string]bool{
+	"-v":       true,
+	"-b":       true,
+	"-e":       true,
+	"-k":       true,
+	"-country": true,
+	"-cfon":    true,
+	"-gool":    true,
+	"-scan":    true,
+}
+
+func newFlags() *Flags {
+	return &Flags{}
+}
+
+func (f *Flags) setup() {
+	flag.BoolVar(&f.Verbose, "v", false, "verbose")
+	flag.StringVar(&f.BindAddress, "b", "127.0.0.1:8086", "socks bind address")
+	flag.StringVar(&f.Endpoint, "e", "notset", "warp clean IP")
+	flag.StringVar(&f.License, "k", "notset", "license key")
+	flag.StringVar(&f.Country, "country", "", "psiphon country code in ISO 3166-1 alpha-2 format")
+	flag.BoolVar(&f.PsiphonEnabled, "cfon", false, "enable Psiphon over warp")
+	flag.BoolVar(&f.Gool, "gool", false, "enable warp gooling")
+	flag.BoolVar(&f.Scan, "scan", false, "enable warp scanner(experimental)")
 
 	flag.Usage = usage
 	flag.Parse()
+}
+
+var validCountryCodes = map[string]bool{
+	"AT": true,
+	"BE": true,
+	"BG": true,
+	"BR": true,
+	"CA": true,
+	"CH": true,
+	"CZ": true,
+	"DE": true,
+	"DK": true,
+	"EE": true,
+	"ES": true,
+	"FI": true,
+	"FR": true,
+	"GB": true,
+	"HU": true,
+	"IE": true,
+	"IN": true,
+	"IT": true,
+	"JP": true,
+	"LV": true,
+	"NL": true,
+	"NO": true,
+	"PL": true,
+	"RO": true,
+	"RS": true,
+	"SE": true,
+	"SG": true,
+	"SK": true,
+	"UA": true,
+	"US": true,
+}
+
+func usage() {
+	log.Println("./warp-plus-go [-v] [-b addr:port] [-c config-file-path] [-e warp-ip] [-k license-key] [-country country-code] [-cfon] [-gool]")
+	flag.PrintDefaults()
+}
+
+func validateFlags(f *Flags) error {
+	if _, err := net.ResolveTCPAddr("tcp", f.BindAddress); err != nil {
+		return fmt.Errorf("invalid bindAddress format: %s", f.BindAddress)
+	}
+
+	if ip := net.ParseIP(f.Endpoint); ip == nil {
+		return fmt.Errorf("invalid warp clean IP: %s", f.Endpoint)
+	}
+
+	if f.PsiphonEnabled && f.Country == "" {
+		return fmt.Errorf("if Psiphon is enabled, country code must be provided")
+	}
+
+	if !validCountryCodes[f.Country] {
+		validCountries := make([]string, 0, len(validCountryCodes))
+
+		for code, _ := range validCountryCodes {
+			validCountries = append(validCountries, code)
+		}
+
+		return fmt.Errorf("invalid country code: %s. Valid country codes: $s", f.Country, validCountries)
+	}
+
+	return nil
+}
+
+func main() {
+	// Check for unexpected flags
+	for _, arg := range os.Args[1:] {
+		if !validFlags[arg] {
+			log.Fatalf("Invalid flag: %s", arg)
+		}
+	}
+
+	flags := newFlags()
+	flags.setup()
+
+	if err := validateFlags(flags); err != nil {
+		log.Fatalf("Validatrion error: %v", err)
+	}
 
 	sigchan := make(chan os.Signal)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGTERM)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		err := app.RunWarp(*psiphonEnabled, *gool, *scan, *verbose, *country, *bindAddress, *endpoint, *license, ctx, *rtt)
+		err := app.RunWarp(flags.PsiphonEnabled, flags.Gool, flags.Scan, flags.Verbose, flags.Country, flags.BindAddress, flags.Endpoint, flags.License, ctx)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type Flags struct {
 	PsiphonEnabled bool
 	Gool           bool
 	Scan           bool
+	Rtt            int
 }
 
 var validFlags = map[string]bool{
@@ -33,6 +34,7 @@ var validFlags = map[string]bool{
 	"-cfon":    true,
 	"-gool":    true,
 	"-scan":    true,
+	"-rtt":     true,
 }
 
 func newFlags() *Flags {
@@ -48,6 +50,7 @@ func (f *Flags) setup() {
 	flag.BoolVar(&f.PsiphonEnabled, "cfon", false, "enable Psiphon over warp")
 	flag.BoolVar(&f.Gool, "gool", false, "enable warp gooling")
 	flag.BoolVar(&f.Scan, "scan", false, "enable warp scanner(experimental)")
+	flag.IntVar(&f.Rtt, "rtt", 1000, "scanner rtt threshold, default 1000")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -137,7 +140,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		err := app.RunWarp(flags.PsiphonEnabled, flags.Gool, flags.Scan, flags.Verbose, flags.Country, flags.BindAddress, flags.Endpoint, flags.License, ctx)
+		err := app.RunWarp(flags.PsiphonEnabled, flags.Gool, flags.Scan, flags.Verbose, flags.Country, flags.BindAddress, flags.Endpoint, flags.License, ctx, flags.Rtt)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
* Added validation for `bindAddress`, ensuring it is a valid IP address.
* Implemented validation for `warp clean IP.`
* Added validation for the Psiphon country code, with a comprehensive list of supported codes.
* Implemented a check for unexpected flags to enhance user input validation.
* Updated the example usage to reflect the changes in flag validations.