### PR TITLE
warp/endpoint.go: add 2 prefixes

### DIFF
--- a/warp/endpoint.go
+++ b/warp/endpoint.go
@@ -22,6 +22,13 @@ func WarpPrefixes() []netip.Prefix {
 	}
 }
 
+func WarpNAT64Prefixes() []netip.Prefix {
+	return []netip.Prefix{
+		netip.MustParsePrefix("2a02:898:146:64::a29f:c000/120"),
+		netip.MustParsePrefix("2001:67c:2960:6464::a29f:c000/120"),
+	}
+}
+
 func RandomWarpPrefix(v4, v6 bool) netip.Prefix {
 	if !v4 && !v6 {
 		panic("Must choose a IP version for RandomWarpPrefix")


### PR DESCRIPTION
https://ipng.ch/s/articles/2024/06/29/coloclue-ipng.html
https://noc.level66.network/services/nat64/
NAT64 gateways can be used as endpoints too.